### PR TITLE
Integrate crossword app

### DIFF
--- a/puzzles/lacrosse_town_crossword.py
+++ b/puzzles/lacrosse_town_crossword.py
@@ -1,0 +1,30 @@
+import requests
+import json
+from django.conf import settings
+from puzzles.models import Puzzle, LacrosseTownCrossword
+
+# returns URL
+def create_lacrosse_town_crossword():
+    params = {
+        "type": "new",
+    }
+    result = requests.post(
+        settings.LACROSSE_TOWN_CROSSWORD_DOMAIN + "/api",
+        data={"params": json.dumps(params)})
+
+    result = json.loads(result.text)
+
+    if not result["success"]:
+        raise Exception("crossword api did not return success")
+    if not result["url"]:
+        raise Exception("crossword api did not return a URL")
+
+    return result["url"]
+
+def add_crossword_for_puzzle(puzzle):
+    url = create_lacrosse_town_crossword()
+
+    LacrosseTownCrossword.objects.create(
+        puzzle=puzzle,
+        url=url,
+        is_deleted=False)

--- a/puzzles/management/commands/initial_config.py
+++ b/puzzles/management/commands/initial_config.py
@@ -45,7 +45,7 @@ class Command(BaseCommand):
         testing_taglist.tags = [Tag.objects.get(name='testing')]
         testing_taglist.save()
 
-        default_locations = ['Cambridge', 'remote']
+        default_locations = ['Cambridge', 'remote', 'unknown']
         Location.objects.all().delete()
         for location_name in default_locations:
             Location(name=location_name).save()

--- a/puzzles/models.py
+++ b/puzzles/models.py
@@ -166,6 +166,14 @@ class Location(OrderedModel):
     def __unicode__(self):
         return self.name
 
+class LacrosseTownCrossword(OrderedModel):
+    puzzle = models.ForeignKey('Puzzle')
+    url = models.CharField(max_length=200)
+    is_deleted = models.BooleanField()
+
+    def __unicode__(self):
+        return self.url
+
 class UserProfile(models.Model):
     user = models.OneToOneField(User)
 

--- a/puzzles/static/css/base.css
+++ b/puzzles/static/css/base.css
@@ -441,6 +441,29 @@ div#answers a#callinanswer:hover {
     padding-left: 10px;
 }
 
+.puzzle-blurb div#add_crossword {
+    display: inline-block;
+    padding-left: 10px;
+}
+
+#delete_crossword_form {
+    padding-left: 200px;
+}
+
+.delete_crossword_form_hidden {
+    display: none;
+}
+
+input[type=button].collaboration_link_button_sel {
+	background-color: #66ffff;
+	border-color: #66ffff;
+	box-shadow: inset;
+}
+
+input[type=button].collaboration_link_button {
+	cursor: pointer;
+}
+
 span.puzzle-title {
     font-weight: bold;
 }

--- a/solving/local_settings_template.py
+++ b/solving/local_settings_template.py
@@ -46,3 +46,5 @@ ZULIP_SERVER_URL = 'https://' + ZULIP_SERVER_HOSTNAME
 import random
 ZULIP_HOSTNAME_BALANCING = lambda: 'https://e%d.%s' % (
     random.randint(1, 100), ZULIP_SERVER_HOSTNAME)
+
+LACROSSE_TOWN_CROSSWORD_DOMAIN = 'http://enigmatic-mountain-8851.herokuapp.com'

--- a/solving/urls.py
+++ b/solving/urls.py
@@ -18,6 +18,8 @@ urlpatterns = patterns('',
     url(r'^puzzle/set_priority/(\d+)/$', 'puzzles.views.puzzle_set_priority'),
     url(r'^puzzle/remove_solver/(\d+)/$', 'puzzles.views.puzzle_remove_solver'),
     url(r'^puzzle/add_solver/(\d+)/$', 'puzzles.views.puzzle_add_solver'),
+    url(r'^puzzle/add_crossword/(\d+)/$', 'puzzles.views.puzzle_add_crossword'),
+    url(r'^puzzle/delete_crossword/(\d+)/$', 'puzzles.views.puzzle_delete_crossword'),
     url(r'^puzzle/upload/(\d+)/$', 'puzzles.views.puzzle_upload'),
     url(r'^puzzle/call_in_answer/(\d+)/$', 'puzzles.views.puzzle_call_in_answer'),
 

--- a/templates/puzzles/puzzle-frames.html
+++ b/templates/puzzles/puzzle-frames.html
@@ -3,11 +3,16 @@
 <head>
 <title>{{ title }}</title>
 <link rel="icon" href="{{ STATIC_URL }}img/favicon.ico" />
+<script type="text/javascript">
+	function setCollaborationSrc(src) {
+		document.getElementById('collaboration_frame').setAttribute('src', src);
+	}
+</script>
 </head>
 <frameset rows="150px,*" title="{{ title }}">
   <frame src="{% url 'puzzles.views.puzzle_info' id %}" />
   <frameset cols="*,390px">
-    <frame src="{% url 'puzzles.views.puzzle_spreadsheet' id %}" />
+    <frame src="{% url 'puzzles.views.puzzle_spreadsheet' id %}" id="collaboration_frame" />
     <frame src="{% url 'puzzles.views.puzzle_chat' id %}" />
   </frameset>
 </frameset>

--- a/templates/puzzles/puzzle-info.html
+++ b/templates/puzzles/puzzle-info.html
@@ -39,6 +39,13 @@
     </select>
     </div>
 
+    <div id="add_crossword">
+      <form action="{% url 'puzzles.views.puzzle_add_crossword' puzzle.id %}" method="post">{% csrf_token %}
+        <input type="hidden" name="continue" value="{{ path }}" />
+        <input type="submit" value="+ Collabortive Crossword Sheet">
+      </form>
+    </span>
+
     <div id="puzzlefiles">
   <a id="attachfile" href="{% url 'puzzles.views.puzzle_upload' puzzle.id %}">Attach file</a>
   {% if uploaded_files %}Attached files:
@@ -123,5 +130,59 @@
     </form>
   </span>
 </div>
+
+<script type="text/javascript">
+    function collaborationGoTo(target) {
+        // Unselect the previously selected button
+        var currentlySelected = Array.prototype.slice.call(
+            document.getElementsByClassName("collaboration_link_button_sel"));
+        for (var i = 0; i < currentlySelected.length; i++) {
+            currentlySelected[i].setAttribute('class', 'collaboration_link_button')
+            currentlySelected[i].removeAttribute('disabled');
+        }
+
+        // Select the newly-clicked button
+        target.setAttribute('class', 'collaboration_link_button_sel');
+        target.setAttribute('disabled', 'true');
+
+        // Set the frame's source
+        var src = target.getAttribute('data-src');
+        parent.setCollaborationSrc(src);
+
+        // Update the delete button form
+        var crossword_id = target.getAttribute('data-crossword-id');
+        var form = document.getElementById('delete_crossword_form');
+        if (crossword_id == "") {
+            form.setAttribute('class', 'delete_crossword_form_hidden');
+        } else {
+            form.setAttribute('class', '');
+        }
+        document.getElementById('crossword_id_input').value = crossword_id;
+    }
+
+    // Makes sure that all the state is correct for the initially
+    // selected item.
+    window.addEventListener('load', function() {
+        collaborationGoTo(document.getElementsByClassName('collaboration_link_button_sel')[0]);
+    });
+</script>
+<div id="collaboration_links" style="{% if hide_collaboration_links %}display: none{% endif %}">
+    {% for collaboration_link in collaboration_links %}
+        <input type="button"
+            class="{% if collaboration_link.selected %}collaboration_link_button_sel{%else%}collaboration_link_button{%endif%}"
+            onClick="collaborationGoTo(event.target)"
+            value="{{ collaboration_link.text }}"
+            data-src="{{ collaboration_link.url }}"
+            data-crossword-id="{{ collaboration_link.id }}">
+    {% endfor %}
+    <form id="delete_crossword_form" action="{% url 'puzzles.views.puzzle_delete_crossword' puzzle.id %}"
+            method="post" class="delete_crossword_form_hidden"
+            >{% csrf_token %}
+        <input type="hidden" name="continue" value="{{ path }}">
+        <input type="hidden" name="crossword_id" value="" id="crossword_id_input">
+        <input type="submit" value="Delete this crossword sheet">
+    </form>
+</div>
+
 </div>
 {% endblock %}


### PR DESCRIPTION
I apologize for the extreme last-minute-ness of this.

I wrote a real-time collaborative crossword-solving app and integrated it into our (Hunches in Bunches') fork of this software. You guys are completely welcome to use it too, if you want.

I'm currently running the site on heroku:
https://enigmatic-mountain-8851.herokuapp.com/new

A demo puzzle (a crossword from last year's hunt):
https://enigmatic-mountain-8851.herokuapp.com/puzzle/3a1e97da78d070f253d7e7dfe87df62c619c0245f4d57f44aa886958403ec6d37174d25fbe69926debbab9937602f36a

The philosophy is to be flexible (because mystery hunt will be full of surprises) while also being optimized for common crossword cases (matching patterns). Usage information is at the bottom of the page.

The source for the app is at https://github.com/tjhance/lacrosse-town

This PR is the patch I applied to our fork of `metaphysical-solving`. It uses my currently-deployed instance (which you are welcome to use, too).

The URLs to the crossword sheets are stored in a new table.
Users can manually add crossword sheets (as many per puzzle
as desired) with a button in the puzzle info panel.
    
The crossword sheets go in the same frame as the the google sheet. The user can tab the google
sheet and the crossword sheet(s) using some janky JavaScript. Also, the view defaults to the crossword sheet when there is
at least one. There is also a button to delete crossword sheets from puzzles.

If you end up using it, please let me know any feedback you have! (Although I clearly won't be able to make any fixes before hunt.)

Regardless, happy hunting! :)