### PR TITLE
Remove borders from frames to avoid overflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 solving/local_settings.py
 puzzles/__pycache__
+env/

--- a/templates/puzzles/puzzle-bottomframes.html
+++ b/templates/puzzles/puzzle-bottomframes.html
@@ -4,7 +4,7 @@
   <head>
     <title>{{ title }}</title>
   </head>
-    <frameset cols="*,390px">
+    <frameset cols="*,390px" border="3" bordercolor="#999">
       <frame src="{% url 'puzzles.views.puzzle_spreadsheet' id %}" />
       <frame src="{% url 'puzzles.views.puzzle_chat' id %}" />
     </frameset>

--- a/templates/puzzles/puzzle-newframes.html
+++ b/templates/puzzles/puzzle-newframes.html
@@ -84,6 +84,6 @@
   <div id="topbar" style="height: 65px;">
      {% include "puzzles/puzzle-newinfo.html" %}
   </div>
-  <iframe src="{% url 'puzzles.views.puzzle_bottom' id %}" style="width:100%; height:calc(100% - 65px);"></iframe>
+  <iframe src="{% url 'puzzles.views.puzzle_bottom' id %}" style="width:100%; height:calc(100% - 65px); border: 0;"></iframe>
 </body>
 </html>


### PR DESCRIPTION
- Set the iframe borders to 0 (non-0 borders were causing overflow on the puzzle page and a bit of world-scrolling).
- Reduced the size of the border between the spreadsheet and zulip frames.
- Added env to .gitignore