### PR TITLE
Add settings to remove warning messages, and add helpful make commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+# Variables
+VENV = ./env
+MANAGE = $(VENV)/bin/python manage.py
+
+# Run Django server on port 8080
+.PHONY: run
+run:
+	$(MANAGE) runserver 8080
+
+# Make Django migrations
+.PHONY: makemigrations
+makemigrations:
+	$(MANAGE) makemigrations
+
+# Apply Django migrations
+.PHONY: migrate
+migrate:
+	$(MANAGE) migrate

--- a/solving/settings.py
+++ b/solving/settings.py
@@ -20,7 +20,8 @@ TEMPLATES = [
         'OPTIONS': {
             'context_processors': [
                 'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages'
+                'django.contrib.messages.context_processors.messages',
+                'django.template.context_processors.request',
             ]
         },
     },
@@ -157,3 +158,6 @@ INSTALLED_APPS = (
     'ordered_model',
     'puzzles'
 )
+
+# Needed to avoid warnings for Django 3.2+
+DEFAULT_AUTO_FIELD='django.db.models.AutoField'


### PR DESCRIPTION
* Add a couple settings the absence of which causes warnings in Django on server launch.
* Add make commands:
   * `make run` launches the server on port 8080
   * `make makemigrations` generates db migrations
   * `make migrate` applies db migrations.
 
