### PR TITLE
Puzzle page facelift, part 1

### DIFF
--- a/puzzles/admin.py
+++ b/puzzles/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from ordered_model.admin import OrderedModelAdmin
-from puzzles.models import Round, Status, Priority, Tag, AutoTag, TagList, Location, Puzzle, SubmittedAnswer, \
-    PuzzleWrongAnswer, Config, AccessLog, JitsiRooms, PuzzleFolder, PuzzleTemplate, QueuedHint
+from puzzles.models import Round, Status, Priority, Tag, AutoTag, TagList, UploadedFile, Location, Puzzle, SubmittedAnswer, \
+    PuzzleWrongAnswer, Config, AccessLog, JitsiRooms, PuzzleFolder, PuzzleTemplate, QueuedAnswer, QueuedHint
 
 
 class SlugAdmin(OrderedModelAdmin):
@@ -53,4 +53,6 @@ class DriveAdmin(OrderedModelAdmin):
 admin.site.register(PuzzleFolder,DriveAdmin)
 admin.site.register(PuzzleTemplate,DriveAdmin)
 
+admin.site.register(UploadedFile,admin.ModelAdmin)
+admin.site.register(QueuedAnswer,OrderedModelAdmin)
 admin.site.register(QueuedHint,OrderedModelAdmin)

--- a/puzzles/static/css/new-base.css
+++ b/puzzles/static/css/new-base.css
@@ -28,9 +28,10 @@
     /* #dce9dc */
     --tag-background: #c7dfff;
     --low-priority: #dae0e9;
-    --normal-priority: #ffffff;
+    --normal-priority: #f1f1f1;
     --high-priority: #f1c285;
     --asap-priority: #ff5b00;
+    --round-header-background: #11494f3d;
 }
 
 /* Reset margins, padding, and sizing on everything */
@@ -92,6 +93,12 @@ select {
     justify-content: space-between;
     align-items: center;
     padding: 0 20px;
+
+    &.compact-header {
+        height: 30px;
+        padding: 7px 8px 5px 6px;
+        border-bottom: none;
+    }
 }
 
 /* Header contents, set max width, alignment, and padding */
@@ -112,17 +119,34 @@ select {
     display: flex;
     justify-content: center;
     align-items: start;
+
+    .compact-header & {
+        margin-left: 10px;
+    }
 }
 
 .logo-image {
     width: 30px;
     height: 30px;
     display: flex;
+    align-self: center;
+
+    .compact-header & {
+        width: 20px;
+        height: 20px;
+    }
 }
 
 .teamname-text {
     display: flex;
     margin-left: 10px;
+
+    .compact-header & {
+        margin-left: 6px;
+        font-size: 14px;
+        font-weight: 500;
+        color: var(--gray-500);
+    }
 }
 
 @media (max-width: 900px) {
@@ -147,13 +171,25 @@ select {
     margin-right: 10px;
     line-height: 0.9em;
 
+    .compact-header & {
+        line-height: 0.7em;
+    }
+
     & .username {
         font-size: 0.9em;
         font-weight: 500;
     }
 
+    .compact-header & .username {
+        font-size: 0.7em;
+    }
+
     & .location {
         font-size: 0.7em;
+    }
+
+    .compact-header & .location {
+        font-size: 0.5em;
     }
 }
 
@@ -174,7 +210,13 @@ select {
     height: auto;
     border-radius: 35px;
     border: 1px solid var(--gray-500);
+
+    .compact-header & {
+        width: 25px;
+        border-radius: 25px;
+    }
 }
+
 
 .user-avatar.big {
     width: 80px;
@@ -254,7 +296,14 @@ select {
     display: flex;
     align-items: center;
     font-size: 16px;
+
+    .compact-header & {
+        padding: 3px;
+        font-size: 14px;
+        border-radius: 0.2rem;
+    }
 }
+
 
 .menu-button:hover {
     background: var(--gray-300);
@@ -412,6 +461,11 @@ select {
     scrollbar-width: none;
     -ms-overflow-style: none;
 
+    .compact-header & {
+        font-size: 12px;
+        padding: 5px 10px 3px 10px;
+    }
+
     & .motd-content {
         display: inline-block;
         white-space: nowrap;
@@ -550,6 +604,7 @@ select {
     font-size: 14px;
     color: #4b5563;
     user-select: none;
+    -webkit-user-select: none;
     /* Gray text */
 }
 
@@ -665,6 +720,7 @@ select {
     color: #374151;
     transition: background-color 0.15s ease;
     user-select: none;
+    -webkit-user-select: none;
 }
 
 .dropdown-item:hover {
@@ -890,31 +946,6 @@ select {
     }
 }
 
-.priority-badge {
-    margin-left: 4px;
-    position: relative;
-    top: 2px;
-
-    & .low {
-        color: var(--low-priority);
-    }
-
-    & .normal {
-        color: var(--normal-priority);
-    }
-
-    & .high {
-        color: var(--high-priority);
-    }
-
-    & .asap {
-        display: inline-block;
-        margin-top: 3px;
-        color: var(--asap-priority);
-        animation: pulsate 1.5s infinite;
-    }
-}
-
 .status-badge {
     padding: 2px 6px;
     border-radius: 4px;
@@ -924,6 +955,7 @@ select {
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
     align-self: start;
     user-select: none;
+    -webkit-user-select: none;
 }
 
 .status-badge:hover:after {
@@ -939,8 +971,8 @@ select {
     text-transform: uppercase;
 }
 
-.status-badge.low-priority {
-    background: var(--low-priority);
+.low-priority {
+    background: var(--low-priority) !important;
     color: var(--gray-500);
 }
 
@@ -949,8 +981,8 @@ select {
     content: "Low";
 }
 
-.status-badge.normal-priority {
-    background: var(--normal-priority);
+.normal-priority {
+    background: var(--normal-priority) !important;
 }
 
 .status-badge.normal-priority:hover:after {
@@ -958,8 +990,8 @@ select {
     background: var(--normal-priority);
 }
 
-.status-badge.high-priority {
-    background: var(--high-priority);
+.high-priority {
+    background: var(--high-priority) !important;
 }
 
 .status-badge.high-priority:hover:after {
@@ -967,8 +999,8 @@ select {
     background: var(--high-priority);
 }
 
-.status-badge.asap-priority {
-    background: var(--asap-priority);
+.asap-priority {
+    background: var(--asap-priority) !important;
     animation: pulsate 1.5s infinite;
 }
 
@@ -1019,6 +1051,7 @@ select {
     color: var(--gray-500);
     margin-right: 5px;
     user-select: none;
+    -webkit-user-select: none;
     text-decoration: none;
 }
 
@@ -1083,4 +1116,291 @@ select {
         line-height: 0;
         padding: 7.5px;
     }
+}
+
+/* Puzzle page styles */
+
+#dialog-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: 101;
+    background: rgba(0,0,0,0.6);
+    display: none;
+}
+
+#dialog-window {
+    position: fixed;
+    top: 50px;
+    left: 50vw;
+    transform: translateX(-50%);
+    min-height: 250px;
+    background: white;
+    border-radius: 0.5rem;
+    box-shadow: var(--gray-500) 0px 0px 2px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: space-around;
+    padding: 20px 10px;
+    text-align: center;
+    z-index: 102;
+    display: none;
+
+    & #dialog-window-close-button {
+        position: absolute;
+        right: 10px;
+        top: 10px;
+        cursor: pointer;
+    }
+}
+
+.puzzle-info-bar {
+    width: 100%;
+    height: 30px;
+    background: white;
+    text-align: center;
+    padding: 3px;
+    border-bottom: 1px solid var(--gray-200);
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    padding: 2px 6px;
+
+    & .puzzle-name {
+        font-size: 15px;
+        font-weight: 600;
+        margin-right: 5px;
+        line-height: 15px;
+    }
+
+    & .puzzle-chevron {
+        font-weight: 600;
+        margin: 0 3px 0 5px;
+        position: relative;
+        top: 1px;
+    }
+
+    & .infobar-section {
+        margin: 0 8px;
+        display: flex;
+        line-height: 15px;
+        align-items: center;
+        color: var(--primary);
+    }
+
+    & .infobar-badge {
+        box-shadow: 0 0 2px rgba(0, 0, 0, 0.2);
+        padding: 2px 5px;
+        font-size: 12px;
+        border-radius: 3px;
+        background: var(--gray-100);
+        user-select: none;
+        position: relative;
+    }
+
+    & .infobar-badge.editable {
+        cursor: pointer;
+    }
+
+    & .infobar-badge.editable:hover:after {
+        content: "\eb04";
+        font-family: 'tabler-icons';
+        position: absolute;
+        font-size: 12px;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        border: -1px solid var(--gray-200);
+        background: rgba(255, 255, 255, 0.9);
+        border-radius: 3px;
+        line-height: 18px;
+    }
+
+    & .infobar-answer {
+        background: var(--success);
+        color: white;
+    }
+
+    & .infobar-link {
+        color: var(--primary);
+    }
+
+    & .infobar-action-link {
+        border-bottom: 1px solid var(--gray-300);
+
+        &:hover {
+            color: black;
+        }
+    }
+
+    & .video-chat-link {
+        cursor: pointer;
+    }
+}
+
+/* Split frames */
+
+.split {
+    display: flex;
+    height: calc(100vh - 80px);
+    overflow: hidden;
+    user-select: none;
+}
+
+.gutter {
+    background-color: var(--gray-200);
+    position: relative;
+}
+
+.gutter.gutter-horizontal {
+    cursor: col-resize;
+    width: 10px;
+}
+
+.frame {
+    overflow: hidden;
+    background: white;
+}
+
+.frame iframe {
+    width: 100%;
+    height: 100%;
+    border: none;
+}
+
+#toggle-arrow {
+    position: absolute;
+    bottom: 6px;
+    right: 0px;
+    width: 24px;
+    height: 24px;
+    background-color: #fff;
+    border: 1px solid #eee;
+    border-right: none;
+    border-radius: 10px 0 0 10px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 101;
+    transition: transform 0.3s ease;
+    box-shadow: -2px 0px 2px #eee, inset -5px 0 6px #eee;
+}
+
+#grip-handle {
+    padding: 1px 0;
+    position: absolute;
+    top: 50vh;
+    transform: translateY(-50%);
+    left: -5px;
+    border: 1px solid #eee;
+    border-radius: 4px;
+    cursor: inherit;
+    font-size: 14px;
+    background: #eee;
+    box-shadow: 0 0 2px rgba(0, 0, 0, 0.2);
+}
+
+#toggle-arrow .toggle-arrow-icon {
+    transition: transform 0.3s ease;
+}
+
+#toggle-arrow:hover {
+    background-color: #f5f5f5;
+}
+
+#toggle-arrow.collapsed .toggle-arrow-icon {
+    transform: translateX(-1px) rotate(180deg);
+}
+
+/* Inline video */
+#inline-video {
+    display: none;
+    box-sizing: border-box;
+    border-radius: 10px;
+    box-shadow: var(--gray-500) 0px 0px 2px;
+    background: white;
+    z-index: 102;
+    position: absolute;
+    top: calc(50vh - 120px);
+    left: calc(50vw - 160px);
+    width: 320px;
+    height: 240px;
+    user-select: none;
+    overflow: hidden;
+    border: 1px solid rgba(0,0,0,0);
+    padding: 3px;
+
+    & #video-titlebar {
+        width: 100%;
+        height: 25px;
+        background: var(--primary);
+        color: white;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        font-size: 12px;
+        padding: 0 8px;
+        border-radius: 5px 5px 0 0;
+
+        & .titlebar-button {
+            cursor: pointer;
+            font-weight: 500;
+        }
+    }
+
+    & #internal-video-resize-overlay {
+        position: absolute;
+        z-index: 10;
+        width: 100%;
+        height: calc(100% - 25px);
+        top: 25px;
+        left: 0px;
+        background: rgba(255,255,255,0.2);
+        display: none;
+    }
+
+    & .loading-video {
+        font-size: 15px;
+        height: 15px;
+        width: 15px;
+        line-height: 0;
+        top: 50%;
+        left: 50%;
+        animation: rotate 2s linear infinite;
+        position: absolute;
+        z-index: 1;
+    }
+
+    & #video-content {
+        width: 100%;
+        height: calc(100% - 25px);
+        background: var(--gray-200);
+        overflow: hidden;
+        border-radius: 0 0 5px 5px;
+
+        & .jitsi-video {
+            border: none;
+            width: 200%;
+            height: 200%;
+            transform: scale(0.5) translate(-50%, -50%);
+            position: relative;
+            z-index: 2;
+        }
+    }
+}
+
+#video-resize-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    z-index: 101;
+    background: rgba(0,0,0,0.1);
+    display: none;
 }

--- a/solving/urls.py
+++ b/solving/urls.py
@@ -10,10 +10,14 @@ admin.autodiscover()
 urlpatterns = [
     re_path(r'^$', views.welcome),
 
-    re_path(r'^overview/$', views.overview, name='puzzles.views.overview'),
-    re_path(r'^api_overview', views.api_overview, name="puzzles.views.api_overview"),
-    re_path(r'^api_motd', views.api_motd, name="puzzles.views.api_motd"),
     re_path(r'^profile_photo', views.profile_photo, name='puzzles.views.profile_photo'),
+
+    re_path(r'^api_overview', views.api_overview, name="puzzles.views.api_overview"),
+    re_path(r'^api_log_a_view/(\d+)$', views.api_log_a_view, name="puzzles.views.api_log_a_view"),
+    re_path(r'^api_motd', views.api_motd, name="puzzles.views.api_motd"),
+    re_path(r'^api_puzzle/(\d+)$', views.api_puzzle, name='puzzles.views.api_puzzle'),
+
+    re_path(r'^overview/$', views.overview, name='puzzles.views.overview'),
     re_path(r'^overview/(\d+)/$',  views.overview_by, name='puzzles.views.overview_by'),
     re_path(r'^whowhat/$', views.who_what, name='puzzles.views.who_what'),
     re_path(r'^puzzle/(\d+)/$',  views.puzzle, name='puzzles.views.puzzle'),

--- a/templates/puzzles/base_generic.html
+++ b/templates/puzzles/base_generic.html
@@ -7,12 +7,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="{% static "css/new-base.css" %}?1" />
     <link rel="icon" href="{% static "img/team_logo.svg" %}" />
+    {% block externaljs %}{% endblock %}
     <title>{% block title %}{% endblock %}</title>
   </head>
 {% endif %}
   <body>
-    {% include "puzzles/infoheader.html" %}
-    <div id="content">{% block content %}{% endblock %}</div>
+    {% block header %}
+      {% include "puzzles/infoheader.html" %}
+    {% endblock %}
+   {% block content %}{% endblock %}
   </body>
 {% if not body_only %}
 </html>

--- a/templates/puzzles/infoheader.html
+++ b/templates/puzzles/infoheader.html
@@ -131,7 +131,7 @@
 
 <!-- The page header, containing the menu button, the team logo and name,
      the optional team announcement, as well as the user information -->
-<header class="header">
+<header class="header {{ compact_header }}">
     <div class="header-content">
     <button class="menu-button" onclick="toggleMenu()" title="Menu">
         <i class="ti ti-menu-2"></i>

--- a/templates/puzzles/jitsi_page.html
+++ b/templates/puzzles/jitsi_page.html
@@ -4,7 +4,7 @@
     <html>
       <head>
         <script src='https://8x8.vc/{{jaas_app_id}}/external_api.js' async></script>
-        <style>html, body, #jaas-container { height: 100%; margin:0; border: 0;}</style>
+        <style>html {overflow:hidden;} html, body, #jaas-container { height: 100%; margin:0; border: 0;}</style>
         <script type="text/javascript">
           window.onload = () => {
             const api = new JitsiMeetExternalAPI("8x8.vc", {

--- a/templates/puzzles/overview.html
+++ b/templates/puzzles/overview.html
@@ -5,6 +5,7 @@
 {% block title %}Overview{% endblock %}
 
 {% block content %}
+<div id="content">
 <div class="filtered-view-announcement hidden">
   <i class="ti ti-filter"></i>
     Filtered View (<span class="reset-filters-link" onClick="resetFilters()">Reset</span>)
@@ -67,6 +68,7 @@
             <div class="dropdown-content" id="round-content"></div>
           </div>
         </div>
+</div>
 </div>
 <script>
     // TODO

--- a/templates/puzzles/puzzle-frames.html
+++ b/templates/puzzles/puzzle-frames.html
@@ -1,88 +1,367 @@
+{% extends "puzzles/base_generic.html" %}
+
 {% load static %}
-<html style="width:100%; height:100%;">
-    <head>
-      <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.13.2/themes/smoothness/jquery-ui.css">
-      <link rel="stylesheet" href="{% static "css/base.css" %}?1" />
-      <link rel="stylesheet" href="{% static "css/new-base.css" %}?1" />
-      <link rel="icon" href="{% static "img/favicon.ico" %}" />
-      <title>{% block title %}{{puzzle.title}}{% endblock %}</title>
-      {% if refresh %}
-      <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
-      <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.13.2/jquery-ui.min.js"></script>
-      <script type="text/javascript">
-        function reload() {
-          $.ajax({
-            url: "{% url 'puzzles.views.puzzle_info' id %}",
-            success: function (data, textStatus, jqXHR) { document.getElementById("topbar").innerHTML = data; console.log("Refreshed puzzle info");},
-          });
-        };
-        $(document).ready(
-          function () {
-            $("#open-video-chat-button").click(openVideoChat);
-            setInterval(reload, {{ refresh }} * 1000);
-          });
 
-        function submitform (event) {
-          event.preventDefault();
-          const target = event.currentTarget;
-          console.log(target.action);
-          var xhr = new XMLHttpRequest();
-          var data = new FormData(target);
-          xhr.open('POST',target.action);
-          xhr.send(data);
+{% block header %}{% include "puzzles/infoheader.html" with compact_header="compact-header" %}{% endblock %}
 
-          xhr.onreadystatechange = function() {
-            if (xhr.readyState == XMLHttpRequest.DONE) {
-                reload();
-            }
-          }
-          return false; 
-        };
+{% block title %} {{ puzzle.title }} {% endblock %}
+{% block externaljs %}
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/split.js/1.6.5/split.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/interactjs/dist/interact.min.js"></script>
+{% endblock %}
 
-        function openVideoChat (event) {
-          if (!$("#jitsi-popup").length) {
-          $("#topbar").after(
-            '<div id="jitsi-popup">' +
-            '<img src="{% static "img/videochat.svg" %}" class="jitsi-popup-icon">' + 
-            '<img src="{% static "img/popup-link-icon.svg" %}" id="snapout-popup-button" class="jitsi-popup-snapout-icon">' +
-            '<img src="{% static "img/close-icon.svg" %}" id="close-popup-button" class="jitsi-popup-close-icon">' +
-            '<iframe src="{% url 'puzzles.views.puzzle_jitsi_page' id %}?start_muted=1" style="position:relative; top:-50%; left:-50%; width:200%; height:200%; border: none; transform: scale(0.5);"></iframe>' +
-            '</div>'
-          );
-          $("#jitsi-popup").resizable({
-              minWidth: 100,
-              minHeight: 100,
-              maxWidth: 600,
-              maxHeight: 600
-            }).draggable({
-              containment: "window"
-            });
-            
-            $("#close-popup-button").click(function() {
-              $("#jitsi-popup").remove();
-            });
-
-            $("#snapout-popup-button").click(function() {
-              window.open("{% url 'puzzles.views.puzzle_jitsi_page' id %}", "_new"); 
-              $("#jitsi-popup").remove();
-            });
-
-          }
-        };
-
-        function closeVideoChat (event) {
-          $("#jitsi-popup").remove();
-        }
-      </script>
-      {% endif %}
-    </head>
-<title>{{ title }}</title>
-<link rel="icon" href="{% static "img/favicon.ico" %}" />
-</head>
-<body style="width:100%; height:100%;position:relative;"">
-  <div id="topbar" style="height: 85px;">
-     {% include "puzzles/puzzle-info.html" %}
+{% block content %}
+<div id="puzzle-info-bar" class="puzzle-info-bar">
+  <i class="ti ti-loader-2 loader-icon"></i>
+</div>
+<div id="content" class="split">
+  <div id="left" class="frame">
+    <iframe src="{% url 'puzzles.views.puzzle_spreadsheet' id %}"></iframe>
   </div>
-  <iframe src="{% url 'puzzles.views.puzzle_bottom' id %}" style="width:100%; height:calc(100% - 85px); border: 0;"></iframe>
-</body>
-</html>
+  <div id="right" class="frame">
+    <iframe src="{% url 'puzzles.views.puzzle_chat' id %}"></iframe>
+  </div>
+</div>
+<div id="video-resize-overlay">
+</div>
+<div id="dialog-window">
+  <div id="dialog-window-close-button" onClick="hideDialog()">
+    <i class="ti ti-x"></i>
+  </div>
+  <div id="dialog-window-content">
+  </div>
+</div>
+<div id="dialog-overlay" onClick = "hideDialog()">
+</div>
+</div>
+<div id="inline-video">
+  <div id="video-titlebar">
+    <div class="titlebar-button" title="Open video in new tab" onClick="popoutVideo()">
+      <i class="ti ti-external-link"></i>
+    </div>
+    <div class="video-title">Video chat</div>
+    <div class="titlebar-button" title="Close video" onClick="closeVideo()">
+      <i class="ti ti-x"></i>
+    </div>
+  </div>
+  <div id="internal-video-resize-overlay"></div>
+  <div id="video-content">
+  </div>
+</div>
+<script>
+
+  // Show dialog overlay
+  function showDialogOverlay(html) {
+    document.getElementById("dialog-overlay").style.display = 'block';
+    document.getElementById("dialog-window-content").innerHTML = html ? html : "Dialog window content";
+    document.getElementById("dialog-window").style.display = "block";
+  }
+
+  // Hide dialog overlay
+  function hideDialog() {
+    document.getElementById("dialog-overlay").style.display = 'none';
+    document.getElementById("dialog-window").style.display = 'none';
+  }
+
+  // Show puzzle state (priority and status) edit dialog
+  function editPuzzleState() {
+    showDialogOverlay();
+    
+  }
+
+  // Open video in new tab
+  function popoutVideo() {
+    window.open(document.getElementById("jitsi-video").src, '_blank').focus();
+    closeVideo();
+  }
+
+  // Show video
+  function showVideo(puzzle_id) {
+    document.getElementById("video-content").innerHTML = `
+      <iframe src="/puzzle/jitsi/${puzzle_id}?start_muted=1" id="jitsi-video" class="jitsi-video"></iframe>
+      <div class="loading-video"><i class="ti ti-loader-2"></i></div>
+    `
+    document.getElementById("inline-video").style.display = 'block';
+  }
+
+  // Hide video
+  function closeVideo() {
+    document.getElementById("inline-video").style.display = 'none';
+    document.getElementById("video-content").innerHTML = "";
+  }
+
+  // Show overlay
+  function showVideoOverlay() {
+    document.getElementById("video-resize-overlay").style.display = 'block';
+    document.getElementById("internal-video-resize-overlay").style.display = 'block';
+  }
+
+  // Hide overlay
+  function hideVideoOverlay() {
+    document.getElementById("video-resize-overlay").style.display = 'none';
+    document.getElementById("internal-video-resize-overlay").style.display = 'none';
+  }
+
+    // Make video draggable and resizable
+  interact('#inline-video')
+  .draggable({
+    allowFrom: '#video-titlebar', // Allow dragging only by the title bar
+    ignoreFrom: '.titlebar-button',
+    modifiers: [
+      interact.modifiers.restrictRect({
+        restriction: 'parent'
+      })
+    ],
+    listeners: {
+      start() {
+        showVideoOverlay(); // Show the overlay when dragging starts
+      },
+      move(event) {
+        const target = event.target;
+        const dataX = parseFloat(target.getAttribute('data-x')) || 0;
+        const dataY = parseFloat(target.getAttribute('data-y')) || 0;
+
+        const x = dataX + event.dx;
+        const y = dataY + event.dy;
+
+        target.style.transform = `translate(${x}px, ${y}px)`;
+
+        target.setAttribute('data-x', x);
+        target.setAttribute('data-y', y);
+      },
+      end() {
+        hideVideoOverlay(); // Hide the overlay when dragging ends
+      },
+    },
+  }).resizable({
+    edges: { top: true, left: true, bottom: true, right: true },
+    margin: 10,
+    modifiers: [
+      // keep the edges inside the parent
+      interact.modifiers.restrictEdges({
+        outer: 'parent'
+      }),
+    
+      // minimum size
+      interact.modifiers.restrictSize({
+        min: { width: 100, height: 50 }
+      })
+    ],
+    listeners: {
+      start() {
+        showVideoOverlay(); // Show the overlay when resizing starts
+      },
+      move(event) {
+         var target = event.target;
+         var x = (parseFloat(target.getAttribute('data-x')) || 0);
+         var y = (parseFloat(target.getAttribute('data-y')) || 0);
+
+         // update the element's style
+         target.style.width = event.rect.width + 'px';
+         target.style.height = event.rect.height + 'px';
+
+         // translate when resizing from top or left edges
+         x += event.deltaRect.left;
+         y += event.deltaRect.top;
+
+         target.style.transform = 'translate(' + x + 'px,' + y + 'px)';
+
+         target.setAttribute('data-x', x);
+         target.setAttribute('data-y', y);
+      },
+      end() {
+        hideVideoOverlay(); // Hide the overlay when resizing ends
+      },
+    },
+  });
+
+  // Render puzzle info bar
+  function renderPuzzleInfoBar(data) {
+    let puzzle_priority = data.puzzle.priority ? data.puzzle.priority.replace(/!/g, '') : "normal";
+    let html = `
+       <span class="puzzle-name">
+         <a class="puzzle-name-link infobar-link" href="/puzzle/linkout/${data.puzzle.id}" target="_blank">
+           <i class="ti ti-external-link"></i>
+           ${data.puzzle.round ? data.puzzle.round + `<i class="ti ti-chevron-right puzzle-chevron"></i>` : ""}${data.puzzle.title}
+         </a>
+       </span>
+       <span class="video-chat infobar-section">
+        <div class="video-chat-link infobar-link" onClick="showVideo('${data.puzzle.id}')" title="Open puzzle video chat" target="_blank">
+          <i class="ti ti-video"></i>
+        </div>
+       </span>
+       
+        ${data.puzzle.status ? `
+          <span class="infobar-section">
+          <div class="infobar-badge ${puzzle_priority}-priority editable" onClick = "editPuzzleState()">
+            <i class="ti ti-flag"></i>
+            ${data.puzzle.priority}
+          </div> 
+          </span>` : ''
+        }
+      
+       <span class="infobar-section">
+                         ${data.puzzle.status ? `
+                      <div class="infobar-badge infobar-status editable" onClick = "editPuzzleState()"">
+                        <i class="ti ti-activity"></i>
+                        ${data.puzzle.status}
+                        ${data.puzzle.status === "not started" ? `(<a class="infobar-action-link infobar-start" href="#">start</a>)` : ''}</div> `
+                      : `<div class="infobar-badge infobar-answer"><i class="ti ti-circle-check answer-check"></i>${data.puzzle.answer}</div>`}
+       </span>
+       
+        ${data.puzzle.solvers && data.puzzle.status ?
+          `<span class="infobar-section">
+            <div class="infobar-badge">
+            <i class="ti ti-users"></i>
+            ${data.puzzle.solvers.length} ${data.puzzle.solvers.length == 1 ? 'solver' : 'solvers'}
+            </div>
+           </span>` : '' 
+        }
+
+        ${data.puzzle.uploaded_files ?
+          `<span class="infobar-section">
+            <div class="infobar-badge">
+            <i class="ti ti-paperclip"></i>
+            ${data.puzzle.uploaded_files.length} ${data.puzzle.uploaded_files.length == 1 ? 'attachment' : 'attachments'}
+            </div>
+           </span>` : '' 
+        }
+
+        ${data.puzzle.prior_answers ? 
+           `<span class="infobar-section">
+            <div class="infobar-badge">
+              <i class="ti ti-clipboard-text"></i>
+              Answers:
+              ${data.puzzle.prior_answers.wrong ?
+                `${data.puzzle.prior_answers.wrong.length} wrong` : ''
+              }${data.puzzle.prior_answers.wrong && data.puzzle.prior_answers.queued ? ', ' : ''}
+              ${data.puzzle.prior_answers.queued ?
+                ` 
+                  ${data.puzzle.prior_answers.queued.length} in queue
+                ` : ''
+              }
+            </div>
+            </span>` : ''
+        }
+
+        <span class="infobar-section">
+          <div class="infobar-badge">
+            <i class="ti ti-progress-help"></i>
+            ${data.puzzle.hints.length} ${data.puzzle.hints.length == 1? "hint" : "hints"}
+            ${data.puzzle.hints.length == 0 ? `(<a class="infobar-action-link" href="#">request</a>)` : ''}
+          </div>
+        </span>
+      `;
+
+    document.getElementById("puzzle-info-bar").innerHTML = html;
+  }
+
+  // Update the puzzle info bar
+  async function fetchAndUpdateInfoBar() {
+      try {
+          const response = await fetch("{% url 'puzzles.views.api_puzzle' id %}", {
+            method: "POST",
+            headers: {
+                "X-CSRFToken": "{{ csrf_token }}",
+            }});
+          const data = await response.json();
+          renderPuzzleInfoBar(data);
+      } catch (error) {
+          console.error('Error fetching puzzle data:', error);
+      }
+  }
+
+  // Update the puzzle info bar
+  async function logAView() {
+      if (document.visibilityState === "visible") {
+        try {
+            const response = await fetch("{% url 'puzzles.views.api_log_a_view' id %}", {
+              method: "POST",
+              headers: {
+                  "X-CSRFToken": "{{ csrf_token }}",
+              }});
+        } catch (error) {
+            console.error('Error logging the puzzle view:', error);
+        }
+      }
+  }
+
+  // Initial load
+  fetchAndUpdateInfoBar();
+  logAView();
+
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible") {
+      logAView();
+    }
+  });
+
+  // Update every 60 seconds
+  setInterval(fetchAndUpdateInfoBar, 600000);
+  setInterval(logAView, 60000);
+
+  // Initialize Split.js
+  const split = Split(['#left', '#right'], {
+      sizes: [80, 20],
+      minSize: [200, 0],
+      gutterSize: 5,
+      snapOffset: 0,
+      onDrag: () => {
+          // Update arrow position when dragging
+          updateArrowVisibility();
+      }
+  });
+
+  toggleArrowHTML = `
+  <i class="ti ti-chevron-right toggle-arrow-icon"></i>
+  `
+
+  // Create and append the toggle arrow
+  const gutter = document.querySelector('.gutter');
+  const toggleArrow = document.createElement('div');
+  toggleArrow.id = "toggle-arrow";
+  toggleArrow.innerHTML = toggleArrowHTML;
+  gutter.appendChild(toggleArrow);
+
+  // Create and append the grip handle
+  const gripHandle = document.createElement('div');
+  gripHandle.id = "grip-handle"
+  gripHandle.innerHTML = `<i class="ti ti-grip-vertical"></i>`
+  gutter.appendChild(gripHandle);
+
+  // Handle collapse/expand functionality
+  let isCollapsed = false;
+  const rightPanel = document.getElementById('right');
+  let previousSize = 20;
+
+  toggleArrow.addEventListener('click', (e) => {
+      e.stopPropagation(); // Prevent gutter drag when clicking arrow
+      
+      if (isCollapsed) {
+          split.setSizes([100 - previousSize, previousSize]);
+          rightPanel.style.display = 'block';
+      } else {
+          previousSize = split.getSizes()[1];
+          split.setSizes([100, 0]);
+          rightPanel.style.display = 'none';
+      }
+      
+      isCollapsed = !isCollapsed;
+      toggleArrow.classList.toggle('collapsed');
+  });
+
+  function updateArrowVisibility() {
+      const sizes = split.getSizes();
+      if (sizes[1] < 1) {
+          toggleArrow.classList.add('collapsed');
+          isCollapsed = true;
+          rightPanel.style.display = 'none';
+      } else if (isCollapsed) {
+          toggleArrow.classList.remove('collapsed');
+          isCollapsed = false;
+          rightPanel.style.display = 'block';
+      }
+  }
+</script>
+
+{% endblock %}


### PR DESCRIPTION
1. Replace deprecated <frameset> with Split.JS -- the split now has a nice handle and a collapse/expand button in the bottom.
2. Replace Jitsi inline window with an InteractJS draggable/resizable element; more robust with dragging and resizing because the elements that steal mouse focus are covered by overlays when dragging/resizing.
3. Replace header with a new info header, updated via API (new puzzle API endpoint).
4. Have user activity logged only when the puzzle window is visible or brought back into focus (we can turn that off and make it a regular update instead).